### PR TITLE
Added widget-party widgets to manifest

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1,19 +1,59 @@
 {
     "schema_version": "1",
     "widgets": [{
-        "repository": "https://cdn.rawgit.com/individuo7/dj-dashing-weather-widget/master/widgets/weather/",
-        "name": "weather",
-        "description": "Simple Dashing widget to display weather info. Uses Yahoo's weather API.",
-        "webpage": "https://github.com/individuo7/dj-dashing-weather-widget"
+        "repository": "https://cdn.rawgit.com/mverteuil/widget-party/v2.2.3/widgets/assignment/",
+        "name": "assignment",
+        "description": "A duty assignment widget. Also provides optional expiry and fallback assignee options.",
+        "webpage": "https://github.com/mverteuil/widget-party"
     }, {
+        "repository": "https://cdn.rawgit.com/mverteuil/widget-party/v2.2.3/widgets/buildstatus/",
+        "name": "buildstatus",
+        "description": "A builder state widget for your continuous integration tool (i.e. Jenkins).",
+        "webpage": "https://github.com/mverteuil/widget-party"
+    }, {
+        "repository": "https://cdn.rawgit.com/mverteuil/widget-party/v2.2.3/widgets/commitlist/",
+        "name": "commitlist",
+        "description": "A recent Github commits widget.",
+        "webpage": "https://github.com/mverteuil/widget-party"
+    }, {
+        "repository": "https://cdn.rawgit.com/mverteuil/widget-party/v2.2.3/widgets/fatlist/",
+        "name": "fatlist",
+        "description": "A list widget with a wider stature.",
+        "webpage": "https://github.com/mverteuil/widget-party"
+    }, {
+        "repository": "https://cdn.rawgit.com/mverteuil/widget-party/v2.2.3/widgets/fatnumber/",
+        "name": "fatnumber",
+        "description": "A number widget with a wider stature.",
+        "webpage": "https://github.com/mverteuil/widget-party"
+    }, {
+        "repository": "https://cdn.rawgit.com/mverteuil/widget-party/v2.2.3/widgets/informednumber/",
+        "name": "informednumber",
+        "description": "A number widget for metrics that lack meaningfulness without additional context.",
+        "webpage": "https://github.com/mverteuil/widget-party"
+    }, {        
         "repository": "https://cdn.rawgit.com/torstenfeld/django-dashing-widget-knob/master/widgets/knob/",
         "name": "knob",
         "description": "Simple Django Dashing widget to display a knob chart. Using jQuery Knob.",
         "webpage": "https://github.com/torstenfeld/django-dashing-widget-knob"
     }, {
+        "repository": "https://cdn.rawgit.com/mverteuil/widget-party/v2.2.3/widgets/linklist/",
+        "name": "linklist",
+        "description": "A list of messages with clickable links.",
+        "webpage": "https://github.com/mverteuil/widget-party"
+    }, {
         "repository": "https://cdn.rawgit.com/torstenfeld/django-dashing-widget-numberchange/master/widgets/numberchange/",
         "name": "numberchange",
         "description": "Modified version of the default django-dashing number widget where value is compared to a previous value. Change is indicated through an icon.",
         "webpage": "https://github.com/torstenfeld/django-dashing-widget-numberchange"
+    }, {
+        "repository": "https://cdn.rawgit.com/mverteuil/widget-party/v2.2.3/widgets/sizednumber/",
+        "name": "sizednumber",
+        "description": "A number widget with the power of dynamic font sizing.",
+        "webpage": "https://github.com/mverteuil/widget-party"
+    }, {
+        "repository": "https://cdn.rawgit.com/individuo7/dj-dashing-weather-widget/master/widgets/weather/",
+        "name": "weather",
+        "description": "Simple Dashing widget to display weather info. Uses Yahoo's weather API.",
+        "webpage": "https://github.com/individuo7/dj-dashing-weather-widget"
     }]
 }


### PR DESCRIPTION
Hey there. It's been awhile!

I've finally gotten around to making the widget-party widgets compatible with the plugin system you implemented. I just have a couple of notes about this pull request:
- It seems you guys are using master for the link to the manifest. Rawgit is permanent cache with regard to the CDN pages, so if continuing to suggest to use the `master` link in the `django-dashing` project page, people will not be able to see or use any newly merged widgets because the cache will never expire. We can resolve this by tagging releases when merging new widgets into the repository.
- Within the manifest, you guys are using `master` CDN links as well. This means that you have a only single chance to release your widget correctly, or it will be permanently broken once the first request for it has been cached. I recommend you create tags for your releases and point to the tagged file from the Rawgit CDN rather than this risky `master` based solution.
- I have organized the widgets in the manifest alphabetically by widget name because I've added a non-trivial number of widgets and I think it's hard to manage without a predictable sort order. If you don't want to sort by widget name, that's okay, but there should still be some predictable criteria to use for sorting.

Looking forward to your response. Happy to contribute again. :smile: 
